### PR TITLE
use event API instead of Update method

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -42,23 +42,29 @@ func NewTransmitBinaryOption() *TransmitBinaryOption {
 	return &TransmitBinaryOption{Option: NewOption(TransmitBinary)}
 }
 
+func (t *TransmitBinaryOption) Bind(conn Conn, sink EventSink) {
+	t.Option.Bind(conn, sink)
+	conn.AddListener(t)
+}
+
 func (t *TransmitBinaryOption) Subnegotiation(_ []byte) {}
 
-func (t *TransmitBinaryOption) Update(option byte, theyChanged, them, weChanged, us bool) {
-	if TransmitBinary != option {
+func (t *TransmitBinaryOption) HandleEvent(name string, data any) {
+	event, ok := data.(UpdateOptionEvent)
+	if !ok {
 		return
 	}
 
-	if theyChanged {
-		if them {
+	if event.TheyChanged {
+		if event.Option.EnabledForThem() {
 			t.Conn().SetReadEncoding(Binary)
 		} else {
 			t.Conn().SetReadEncoding(ASCII)
 		}
 	}
 
-	if weChanged {
-		if us {
+	if event.WeChanged {
+		if event.Option.EnabledForUs() {
 			t.Conn().SetWriteEncoding(Binary)
 		} else {
 			t.Conn().SetWriteEncoding(ASCII)

--- a/binary.go
+++ b/binary.go
@@ -44,12 +44,12 @@ func NewTransmitBinaryOption() *TransmitBinaryOption {
 
 func (t *TransmitBinaryOption) Bind(conn Conn, sink EventSink) {
 	t.Option.Bind(conn, sink)
-	conn.AddListener(t)
+	conn.AddListener("update-option", t)
 }
 
 func (t *TransmitBinaryOption) Subnegotiation(_ []byte) {}
 
-func (t *TransmitBinaryOption) HandleEvent(name string, data any) {
+func (t *TransmitBinaryOption) HandleEvent(data any) {
 	event, ok := data.(UpdateOptionEvent)
 	if !ok {
 		return

--- a/binary_test.go
+++ b/binary_test.go
@@ -26,7 +26,7 @@ func TestTransmitBinaryOption(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	conn := NewMockConn(ctrl)
-	conn.EXPECT().AddListener(h)
+	conn.EXPECT().AddListener("update-option", h)
 	h.Bind(conn, nil)
 
 	assert.Equal(t, byte(TransmitBinary), h.Byte())
@@ -38,11 +38,11 @@ func TestTransmitBinaryOption(t *testing.T) {
 	opt.EXPECT().EnabledForUs().Return(false)
 	conn.EXPECT().SetReadEncoding(ASCII)
 	conn.EXPECT().SetWriteEncoding(ASCII)
-	h.HandleEvent("update-option", UpdateOptionEvent{opt, true, true})
+	h.HandleEvent(UpdateOptionEvent{opt, true, true})
 
 	opt.EXPECT().EnabledForThem().Return(true)
 	opt.EXPECT().EnabledForUs().Return(true)
 	conn.EXPECT().SetReadEncoding(Binary)
 	conn.EXPECT().SetWriteEncoding(Binary)
-	h.HandleEvent("update-option", UpdateOptionEvent{opt, true, true})
+	h.HandleEvent(UpdateOptionEvent{opt, true, true})
 }

--- a/charset.go
+++ b/charset.go
@@ -16,6 +16,11 @@ func NewCharsetOption() *CharsetOption {
 	return &CharsetOption{Option: NewOption(Charset)}
 }
 
+func (c *CharsetOption) Bind(conn Conn, sink EventSink) {
+	c.Option.Bind(conn, sink)
+	conn.AddListener(c)
+}
+
 func (c *CharsetOption) Subnegotiation(buf []byte) {
 	if len(buf) == 0 {
 		c.log("RECV: IAC SB %s IAC SE", optionByte(c.Byte()))
@@ -28,8 +33,7 @@ func (c *CharsetOption) Subnegotiation(buf []byte) {
 	switch cmd {
 	case charsetAccepted:
 		c.enc = c.getEncoding(buf)
-		them, us := c.Conn().OptionEnabled(TransmitBinary)
-		c.Update(TransmitBinary, false, them, false, us)
+		c.updateWithBinaryStatus()
 
 	case charsetRejected:
 		c.Sink().SendEvent("charset-rejected", nil)
@@ -65,9 +69,7 @@ func (c *CharsetOption) Subnegotiation(buf []byte) {
 		out = append(out, charset...)
 		out = append(out, IAC, SE)
 		c.send(out)
-
-		them, us := c.Conn().OptionEnabled(TransmitBinary)
-		c.Update(TransmitBinary, false, them, false, us)
+		c.updateWithBinaryStatus()
 	case charsetTTableIs:
 		// We don't support TTABLE, but we don't want to leave our peers hanging
 		// if they send us a TTABLE-IS subnegotiation.
@@ -75,13 +77,18 @@ func (c *CharsetOption) Subnegotiation(buf []byte) {
 	}
 }
 
-func (c *CharsetOption) Update(option byte, theyChanged, them, weChanged, us bool) {
-	switch option {
+func (c *CharsetOption) HandleEvent(name string, data any) {
+	event, ok := data.(UpdateOptionEvent)
+	if !ok {
+		return
+	}
+
+	switch opt := event.Option; opt.Byte() {
 	case TransmitBinary:
 		if c.EnabledForUs() && c.enc != nil {
 			conn := c.Conn()
 			sink := c.Sink()
-			if them && us {
+			if opt.EnabledForThem() && opt.EnabledForUs() {
 				conn.SetEncoding(c.enc)
 				sink.SendEvent("charset-accepted", c.enc)
 			} else {
@@ -116,6 +123,14 @@ func (c *CharsetOption) selectEncoding(names [][]byte) (charset []byte, enc enco
 		}
 	}
 	return
+}
+
+func (c *CharsetOption) updateWithBinaryStatus() {
+	c.HandleEvent("update-option", UpdateOptionEvent{
+		c.Conn().Option(TransmitBinary),
+		false,
+		false,
+	})
 }
 
 func (*CharsetOption) getEncoding(name []byte) encoding.Encoding {

--- a/charset.go
+++ b/charset.go
@@ -18,7 +18,7 @@ func NewCharsetOption() *CharsetOption {
 
 func (c *CharsetOption) Bind(conn Conn, sink EventSink) {
 	c.Option.Bind(conn, sink)
-	conn.AddListener(c)
+	conn.AddListener("update-option", c)
 }
 
 func (c *CharsetOption) Subnegotiation(buf []byte) {
@@ -77,7 +77,7 @@ func (c *CharsetOption) Subnegotiation(buf []byte) {
 	}
 }
 
-func (c *CharsetOption) HandleEvent(name string, data any) {
+func (c *CharsetOption) HandleEvent(data any) {
 	event, ok := data.(UpdateOptionEvent)
 	if !ok {
 		return
@@ -126,7 +126,7 @@ func (c *CharsetOption) selectEncoding(names [][]byte) (charset []byte, enc enco
 }
 
 func (c *CharsetOption) updateWithBinaryStatus() {
-	c.HandleEvent("update-option", UpdateOptionEvent{
+	c.HandleEvent(UpdateOptionEvent{
 		c.Conn().Option(TransmitBinary),
 		false,
 		false,

--- a/charset_test.go
+++ b/charset_test.go
@@ -16,7 +16,7 @@ func withCharsetAndConn(t *testing.T, f func(Option, *MockConn, *MockEventSink))
 	defer ctrl.Finish()
 	conn := NewMockConn(ctrl)
 	sink := NewMockEventSink(ctrl)
-	conn.EXPECT().AddListener(h)
+	conn.EXPECT().AddListener("update-option", h)
 	h.Bind(conn, sink)
 	assert.Equal(t, byte(Charset), h.Byte())
 	f(h, conn, sink)
@@ -109,7 +109,7 @@ func TestAcceptEncodingRequest(t *testing.T) {
 			mockOption.EXPECT().EnabledForUs().Return(true).AnyTimes()
 			co.Option = mockOption
 
-			co.HandleEvent("update-option", UpdateOptionEvent{mockOption, false, true})
+			co.HandleEvent(UpdateOptionEvent{mockOption, false, true})
 			expected := []byte{IAC, SB, Charset, charsetAccepted}
 			expected = append(expected, test.encodingName...)
 			expected = append(expected, IAC, SE)
@@ -220,7 +220,7 @@ func TestUpdateTransmitBinary(t *testing.T) {
 			mockBinary.EXPECT().EnabledForThem().Return(test.them).AnyTimes()
 			mockBinary.EXPECT().EnabledForUs().Return(test.us).AnyTimes()
 
-			co.HandleEvent("update-option", UpdateOptionEvent{mockBinary, test.theyChanged, test.weChanged})
+			co.HandleEvent(UpdateOptionEvent{mockBinary, test.theyChanged, test.weChanged})
 		})
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -124,7 +124,7 @@ func (c *connection) RequestEncoding(enc encoding.Encoding) error {
 	if opt := c.Option(Charset); !opt.EnabledForUs() {
 		return errors.New("charset option not enabled")
 	}
-	msg := []byte{IAC, SB, charsetRequest}
+	msg := []byte{IAC, SB, Charset, charsetRequest, ';'}
 	str, err := ianaindex.IANA.Name(enc)
 	if err != nil {
 		return err
@@ -132,6 +132,7 @@ func (c *connection) RequestEncoding(enc encoding.Encoding) error {
 	msg = append(msg, str...)
 	msg = append(msg, IAC, SE)
 
+	c.Logf("SEND: IAC SB %s %s ;%s IAC SE", optionByte(Charset), charsetByte(charsetRequest), str)
 	_, err = c.Send(msg)
 	return err
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -290,7 +290,7 @@ func TestRequestCharset(t *testing.T) {
 
 	err = conn.RequestEncoding(unicode.UTF8)
 	assert.NoError(t, err)
-	assert.Equal(t, []byte{IAC, SB, charsetRequest, 'U', 'T', 'F', '-', '8', IAC, SE}, out.Bytes())
+	assert.Equal(t, []byte{IAC, SB, Charset, charsetRequest, ';', 'U', 'T', 'F', '-', '8', IAC, SE}, out.Bytes())
 }
 
 func TestSendEvent(t *testing.T) {

--- a/event.go
+++ b/event.go
@@ -1,0 +1,15 @@
+package telnet
+
+type EventListener interface {
+	HandleEvent(any)
+}
+
+type FuncListener struct {
+	Func func(any)
+}
+
+func (f FuncListener) HandleEvent(data any) { f.Func(data) }
+
+type EventSink interface {
+	SendEvent(event string, data any)
+}

--- a/option.go
+++ b/option.go
@@ -2,9 +2,6 @@ package telnet
 
 import "math"
 
-type EventSink interface {
-	SendEvent(event string, data any)
-}
 type Option interface {
 	Allow(them, us bool)
 	Bind(Conn, EventSink)

--- a/test_mocks.go
+++ b/test_mocks.go
@@ -103,19 +103,18 @@ func (mr *MockConnMockRecorder) Logf(arg0 interface{}, arg1 ...interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logf", reflect.TypeOf((*MockConn)(nil).Logf), varargs...)
 }
 
-// OptionEnabled mocks base method.
-func (m *MockConn) OptionEnabled(arg0 byte) (bool, bool) {
+// Option mocks base method.
+func (m *MockConn) Option(arg0 byte) Option {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OptionEnabled", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Option", arg0)
+	ret0, _ := ret[0].(Option)
+	return ret0
 }
 
-// OptionEnabled indicates an expected call of OptionEnabled.
-func (mr *MockConnMockRecorder) OptionEnabled(arg0 interface{}) *gomock.Call {
+// Option indicates an expected call of Option.
+func (mr *MockConnMockRecorder) Option(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionEnabled", reflect.TypeOf((*MockConn)(nil).OptionEnabled), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Option", reflect.TypeOf((*MockConn)(nil).Option), arg0)
 }
 
 // Read mocks base method.
@@ -376,18 +375,6 @@ func (m *MockOption) Subnegotiation(arg0 []byte) {
 func (mr *MockOptionMockRecorder) Subnegotiation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnegotiation", reflect.TypeOf((*MockOption)(nil).Subnegotiation), arg0)
-}
-
-// Update mocks base method.
-func (m *MockOption) Update(arg0 byte, arg1, arg2, arg3, arg4 bool) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3, arg4)
-}
-
-// Update indicates an expected call of Update.
-func (mr *MockOptionMockRecorder) Update(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockOption)(nil).Update), arg0, arg1, arg2, arg3, arg4)
 }
 
 // disableThem mocks base method.

--- a/test_mocks.go
+++ b/test_mocks.go
@@ -35,15 +35,15 @@ func (m *MockConn) EXPECT() *MockConnMockRecorder {
 }
 
 // AddListener mocks base method.
-func (m *MockConn) AddListener(arg0 EventListener) {
+func (m *MockConn) AddListener(arg0 string, arg1 EventListener) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddListener", arg0)
+	m.ctrl.Call(m, "AddListener", arg0, arg1)
 }
 
 // AddListener indicates an expected call of AddListener.
-func (mr *MockConnMockRecorder) AddListener(arg0 interface{}) *gomock.Call {
+func (mr *MockConnMockRecorder) AddListener(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddListener", reflect.TypeOf((*MockConn)(nil).AddListener), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddListener", reflect.TypeOf((*MockConn)(nil).AddListener), arg0, arg1)
 }
 
 // BindOption mocks base method.
@@ -133,15 +133,15 @@ func (mr *MockConnMockRecorder) Read(arg0 interface{}) *gomock.Call {
 }
 
 // RemoveListener mocks base method.
-func (m *MockConn) RemoveListener(arg0 EventListener) {
+func (m *MockConn) RemoveListener(arg0 string, arg1 EventListener) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RemoveListener", arg0)
+	m.ctrl.Call(m, "RemoveListener", arg0, arg1)
 }
 
 // RemoveListener indicates an expected call of RemoveListener.
-func (mr *MockConnMockRecorder) RemoveListener(arg0 interface{}) *gomock.Call {
+func (mr *MockConnMockRecorder) RemoveListener(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockConn)(nil).RemoveListener), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockConn)(nil).RemoveListener), arg0, arg1)
 }
 
 // RequestEncoding mocks base method.


### PR DESCRIPTION
This PR gets rid of the Update method on the Option interface in favor of options implementing HandleEvent and registering with the connection for the `update-option` event in their Bind method.